### PR TITLE
Fixed #14 build error resulting due to change in influxdb

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -470,8 +470,7 @@ func (migrationData *MigrationData) MapWSPToTSMByWhisperFile(from time.Time, unt
 		tsmPoint.key = CreateTSMKey(mtf)
 		tsmPoint.values = make([]tsm1.Value, len(wspPoints))
 		for j, wspPoint := range wspPoints {
-			tsmPoint.values[j] = tsm1.NewValue(
-				time.Unix(int64(wspPoint.Timestamp), 0), wspPoint.Value)
+			tsmPoint.values[j] = tsm1.NewValue(int64(wspPoint.Timestamp), wspPoint.Value)
 		}
 		tsmPoints = append(tsmPoints, tsmPoint)
 	}


### PR DESCRIPTION
The NewValue function was changed to accept
int64 instead of time.Time in this commit
commit 8d70d65a826222800b13cb6be5fc11913976bdb7

Hence, change is needed in migration.go
