### PR TITLE
Changed replacement pattern and allow replacement on all parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ This tool can be used in three modes
 Tag Config file
 
   This file is required to specify tags and measurement name for a given pattern. Please see the sample tagconfig file, migration_config.json
+
+## Replacement pattern
+
+This tool uses golang regexp to process patterns.
+Those are not escaped, so this means you can hack the way it works or run into various issues using it.
+Be careful.
+
+You can use in the metric pattern the format `{{ text1 }}` as a placeholder to a value that you will then be able to reuse in *tags*, *measurement* or *field*. 
+
+The value `{{ text1 }}` is simply replaced by a simple regexp expression: `([^.]+)`.
+
+If no *measurement* is specified, the default value is the last part of the measurement.
+
+If no *field* is specified, the default will be `value`.
+
+Example: For the pattern `carbon.relays.{{ host }}.memUsage`, `measurement=memUsage` and `field=value`

--- a/migration.go
+++ b/migration.go
@@ -570,16 +570,21 @@ func (migrationData *MigrationData) GetMTF(wspFilename string) *MTF {
 	wspFilename = strings.Replace(wspFilename, ",", "_", -1)
 	wspFilename = strings.Replace(wspFilename, " ", "_", -1)
 
-	var patternStr []string
-	var matches [][]int
+	// Filename matching
+	// TODO catch strings that don't match until the end
 	var tagConfig TagConfig
+	var matched []string
 	filenameMatched := false
 	for _, tagConfig = range migrationData.tagConfigs {
-		patternStr = strings.Split(tagConfig.Pattern, "#")
-		re := regexp.MustCompile(patternStr[0])
-		//FindAllIndex returns array of start and end index of the match
-		matches = re.FindAllIndex([]byte(wspFilename), -1)
-		if matches != nil {
+		// Prepare regex pattern
+		pattern := strings.Replace(tagConfig.Pattern, ".", "\\.", -1)
+		pattern = strings.Replace(pattern, "*", "([^.]+)", -1)
+
+		// List the matching values (Base and groups)
+		re := regexp.MustCompile(pattern)
+		matched = re.FindAllStringSubmatch(wspFilename, -1)[0]
+
+		if matched != nil {
 			filenameMatched = true
 			break
 		}
@@ -587,36 +592,41 @@ func (migrationData *MigrationData) GetMTF(wspFilename string) *MTF {
 	if filenameMatched == false {
 		return nil
 	}
-	//extract the string starting at end of the matched pattern
-	//e.g. carbon.relays.eud3-pr-mutgra1-a.whitelistRejects,
-	// the remaining would be eud3-pr-mutgra1-a.whitelistRejects
-	remaining := wspFilename[matches[0][1]:]
 
-	//Split the remaining string on .
-	//e.g. Now the remArr holds eud3-pr-mutgra1-a, whitelistRejects
-	remArr := strings.Split(remaining, ".")
 
-	//patternStr contains pattern split on #
-	//e.g. patternStr[0]carbon.relays. , patternStr[1]TEXT1. , patternStr[2]TEXT2.
+	// Create the migration object
 	var mtf MTF
 
-	//start at i=1, that's #TEXT1 and iterate on all possible # strings in given
-	// pattern
+	// In case measurement and field aren't set in the config file
+	if tagConfig.Measurement != "" {
+		mtf.Measurement = tagConfig.Measurement
+	} else {
+		parts := strings.Split(wspFilename, ".")
+		mtf.Measurement = parts[len(parts)-1]
+	}
+	if tagConfig.Field != "" {
+		mtf.Field = tagConfig.Field
+	} else {
+		mtf.Field = "value"
+	}
 	mtf.Tags = make([]TagKeyValue, len(tagConfig.Tags))
-	for i := 1; i < len(patternStr)-1; i++ {
-		patternTagValue := strings.Trim(patternStr[i], ".")
-		//For each # string, find a match in tag values
-		for j, tagkeyvalue := range tagConfig.Tags {
-			if strings.Trim(tagkeyvalue.Tagvalue, "#") == patternTagValue {
-				mtf.Tags[j].Tagkey = tagkeyvalue.Tagkey
-				//Tag #value is replaced with the actual value
-				mtf.Tags[j].Tagvalue = remArr[i-1]
-			}
+	copy(mtf.Tags, tagConfig.Tags)
+
+	// Replace $# with matched values in order
+	// (reversed to avoid overlapping of bigger numbers)
+	// TODO issues if matched contains "$n"
+	for i := len(matched) - 1; i > 0; i-- {
+		wildcard := fmt.Sprintf("$%d", i)
+
+		mtf.Measurement = strings.Replace(mtf.Measurement, wildcard, matched[i], -1)
+		mtf.Field = strings.Replace(mtf.Field, wildcard, matched[i], -1)
+
+		for j := 0; j < len(mtf.Tags); j++ {
+			mtf.Tags[j].Tagkey = strings.Replace(mtf.Tags[j].Tagkey, wildcard, matched[i], -1)
+			mtf.Tags[j].Tagvalue = strings.Replace(mtf.Tags[j].Tagvalue, wildcard, matched[i], -1)
 		}
 	}
-	// Assign the last string as measurement
-	mtf.Measurement = remArr[len(remArr)-1]
-	mtf.Field = tagConfig.Field
+
 	return &mtf
 }
 

--- a/migration_config.json
+++ b/migration_config.json
@@ -1,37 +1,41 @@
 [
   {
-    "pattern": "carbon.relays.#TEXT1.#TEXT2",
-    "measurement": "#TEXT2",
+    "pattern": "carbon.relays.node-{{ text1 }}-{{ text2 }}.{{ text3 }}",
+    "measurement": "{{ text3 }}",
     "tags": [
       {
         "tagkey": "host",
-        "tagvalue": "#TEXT1"
+        "tagvalue": "{{ text1 }}"
+      },
+      {
+        "tagkey": "country",
+        "tagvalue": "{{ text2 }}"
       }
     ],
     "field": "value"
   },
   {
-    "pattern": "TLM.Sentinel.#TEXT1.#TEXT2.#TEXT3",
-    "measurement": "#TEXT3",
+    "pattern": "TLM.Sentinel.{{ text1 }}.{{ text2 }}.{{ text3 }}",
+    "measurement": "{{ text3 }}",
     "tags": [
       {
         "tagkey": "host",
-        "tagvalue": "#TEXT1"
+        "tagvalue": "{{ text1 }}"
       },
       {
         "tagkey": "computing",
-        "tagvalue": "#TEXT2"
+        "tagvalue": "{{ text2 }}"
       }
     ],
     "field": "something"
   },
   {
-    "pattern": "carbon.agents.#TEXT1.#TEXT2",
-    "measurement": "#TEXT2",
+    "pattern": "carbon.agents.{{ text1 }}.{{ text2 }}",
+    "measurement": "{{ text2 }}",
     "tags": [
       {
         "tagkey": "host",
-        "tagvalue": "#TEXT1"
+        "tagvalue": "{{ text1 }}"
       }
     ],
     "field": "value"


### PR DESCRIPTION
Hi,

I made some changes to the pattern process.
The `#TEXT1` way of doing it doesn't allow chaining them.
With a `{{ text1 }}` pattern it allows to have this kind of extraction:
`carbon.relays.node-{{ host }}-{{ country }}.memUsage`

I also enabled the possibility to use those extracted values in **measurement** and **field** name which somehow was not possible...

I'm happy to share it with the community if it can benefit to someone.

If you need some rebase / changes, please tell me.
