### PR TITLE
bugfix: compiler error

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -512,7 +512,7 @@ func (migrationData *MigrationData) WriteTSMPoints(filename string,
 	for _, tsmPoint := range tsmPoints {
 		//fmt.Println(i, tsmPoint.key)
 		if len(tsmPoint.values) > 0 {
-			if err := tsmWriter.Write(tsmPoint.key, tsmPoint.values); err != nil {
+			if err := tsmWriter.Write([]byte(tsmPoint.key), tsmPoint.values); err != nil {
 				panic(fmt.Sprintf("write TSM value: %v", err))
 			}
 			writes = writes + 1


### PR DESCRIPTION
when i trying to compile the file it throw an error
./migration.go:515: cannot use tsmPoint.key (type string) as type []byte in argument to tsmWriter.Write
